### PR TITLE
Add reload test and extend update test

### DIFF
--- a/tests/tests_reload.yml
+++ b/tests/tests_reload.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that crypto_policy_reload variable works
+  hosts: all
+  tasks:
+
+    - name: Run role to make sure all dependencies are installed
+      include_role:
+        name: linux-system-roles.crypto_policies
+
+    - name: Get SSHD pid before policy update
+      slurp:
+        src: /var/run/sshd.pid
+      register: sshd_pid_before
+
+    - name: Change policy from DEFAULT TO LEGACY (disable reload)
+      include_role:
+        name: linux-system-roles.crypto_policies
+      vars:
+        crypto_policies_policy: LEGACY
+        crypto_policies_reload: false
+
+    - name: Get sshd pid after first update
+      slurp:
+        src: /var/run/sshd.pid
+      register: sshd_pid_after_first
+
+    - name: Verify that policy was changed to LEGACY
+      assert:
+        that:
+          - crypto_policies_active == 'LEGACY'
+    - name: Check the sshd was not reloaded
+      assert:
+        that:
+          - sshd_pid_before.content == sshd_pid_after_first.content
+
+    - name: Change policy from LEGACY to DEFAULT (reload by default)
+      include_role:
+        name: linux-system-roles.crypto_policies
+      vars:
+        crypto_policies_policy: DEFAULT
+
+    - name: Get sshd pid after second update
+      slurp:
+        src: /var/run/sshd.pid
+      register: sshd_pid_after_second
+
+    - name: Verify that policy was changed to DEFAULT
+      assert:
+        that:
+          - crypto_policies_active == 'DEFAULT'
+
+    - name: Check the sshd was reloaded
+      assert:
+        that:
+          - sshd_pid_after_first.content != sshd_pid_after_second.content

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -13,7 +13,7 @@
       block:
         - meta: flush_handlers
 
-        - name: Check the current policy is FUTURE
+        - name: Check the current policy is LEGACY
           assert:
             that:
               - "crypto_policies_active == 'LEGACY'"

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -1,20 +1,67 @@
 # SPDX-License-Identifier: MIT
 ---
-- name: Ensure that we can set the policy using this role without reboot
+- name: Ensure that we can set the policy using this role (without reboot)
   hosts: all
-  roles:
-    - role: linux-system-roles.crypto_policies
+  tasks:
+
+    - name: Set correct base policy
+      include_role:
+        name: linux-system-roles.crypto_policies
       vars:
         crypto_policies_policy: LEGACY
         crypto_policies_reload: false
+    - name: Verify that base policy was updated
+      assert:
+        that:
+          - crypto_policies_active == 'LEGACY'
+          - crypto_policies_reboot_required | bool
 
-  tasks:
-    - name: Verify the facts are correctly set
+    - name: Set correct base policy and policy module
+      include_role:
+        name: linux-system-roles.crypto_policies
+      vars:
+        crypto_policies_policy: DEFAULT:NO-SHA1
+        crypto_policies_reload: false
+    - name: Verify that base policy and policy module were updated
+      assert:
+        that:
+          - crypto_policies_active == 'DEFAULT:NO-SHA1'
+          - crypto_policies_reboot_required | bool
+
+    - name: Setting incorrect base policy should fail
       block:
-        - meta: flush_handlers
-
-        - name: Check the current policy is LEGACY
+        - name: Set incorrect base policy
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: NOEXIST
+            crypto_policies_reload: false
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
           assert:
             that:
-              - "crypto_policies_active == 'LEGACY'"
-              - "crypto_policies_reboot_required == true"
+              - crypto_policies_active == 'DEFAULT:NO-SHA1'
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"
+
+    - name: Setting incorrect policy module should fail
+      block:
+        - name: Set incorrect policy module
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: DEFAULT:NOEXIST
+            crypto_policies_reload: false
+        - name: unreachable task
+          fail:
+            msg: UNREACH
+      rescue:
+        - name: Check that we failed in the role
+          assert:
+            that:
+              - crypto_policies_active == 'DEFAULT:NO-SHA1'
+              - ansible_failed_result.msg != 'UNREACH'
+            msg: "Role has not failed when it should have"


### PR DESCRIPTION
This PR adds test for crypto_policies_reload variable, we check that sshd service is restarted when this variable is set to 'true'. Moreover, test for setting policy module is added to "tests_update".