### PR TITLE
Fix Github actions to pass

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -2,6 +2,7 @@
 name: tox
 on:  # yamllint disable-line rule:truthy
   - pull_request
+  - push
 jobs:
   python:
     runs-on: ubuntu-latest

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -38,7 +38,7 @@ jobs:
           esac
           TOXENV="$toxenvs" .travis/runtox
         env:
-          LSR_ANSIBLES: 'ansible==2.7.* ansible==2.8.* ansible==2.9.*'
+          LSR_ANSIBLES: 'ansible==2.8.* ansible==2.9.*'
           LSR_MSCENARIOS: default
   python-26:
     runs-on: ubuntu-16.04

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -8,7 +8,7 @@ FROM {{ item.image }}
 {% endif %}
 
 RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python3-dnf bash && dnf clean all; \
     elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,9 +9,6 @@ lint:
   options:
     config-file: .yamllint.yml
 platforms:
-  - name: centos-6
-    image: docker.io/linuxsystemroles/centos-6
-    privileged: true
   - name: centos-7
     image: docker.io/linuxsystemroles/centos-7
     volumes:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,9 @@ lint:
   options:
     config-file: .yamllint.yml
 platforms:
-  - name: centos-7
-    image: docker.io/linuxsystemroles/centos-7
+  - name: centos-8
+    image: registry.centos.org/centos:8
+    command: /usr/lib/systemd/systemd --system
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true

--- a/tasks/gather_facts.yml
+++ b/tasks/gather_facts.yml
@@ -3,10 +3,10 @@
 - name: Find out what is the currently active policy
   command: "update-crypto-policies --show"
   changed_when: false
-  check_mode: no
+  check_mode: false
   register: __crypto_policies_active
 
 - name: Set current policy fact
   set_fact:
     crypto_policies_active: "{{ __crypto_policies_active.stdout }}"
-    cacheable: yes
+    cacheable: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     crypto_policies_available_policies: >-
       {{ __crypto_policies_base_policies.files | map(attribute='path')
         | map('basename') | map('splitext') | map('first') | unique | list }}
-    cacheable: yes
+    cacheable: true
 
 - name: Find policy module files
   find:
@@ -49,7 +49,7 @@
     crypto_policies_available_modules: >-
       {{ __crypto_policies_policy_module.files | map(attribute='path')
         | map('basename') | map('splitext') | map('first') | unique | list }}
-    cacheable: yes
+    cacheable: true
 
 - name: Update crypto policy if needed
   command: >

--- a/vars/CentOS_8.yml
+++ b/vars/CentOS_8.yml
@@ -1,1 +1,0 @@
-RedHat_8.yml

--- a/vars/RedHat_8.2.yml
+++ b/vars/RedHat_8.2.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
 
-__crypto_policies_packages: [ "crypto-policies" ]
+__crypto_policies_packages: ["crypto-policies"]

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
 
-__crypto_policies_packages: [ "crypto-policies", "crypto-policies-scripts" ]
+__crypto_policies_packages: ["crypto-policies", "crypto-policies-scripts"]


### PR DESCRIPTION
Remove bogus file as it would be empty as RHEL8 is default at this moment.

Additionally, changes the github workflow configuration to run also on push so we can get results for the badge in the readme.

Change also the molecule configuration to work with CentOS 8 (instead of CentOS 6 and CentOS 7 as they are not supported in this role) and skip ansible 2.7 as it fails to install.