### PR TITLE
Do not install packages that already exist - ansible 2.8

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,10 +14,20 @@
     __crypto_policies_vars_file: "{{ role_path }}/vars/{{ item }}"
   when: __crypto_policies_vars_file is file
 
+- name: Get installed packages
+  package_facts:
+  no_log: true
+
+# There is a bug in ansible 2.8 - the package/dnf module will update packages
+# that already exist.  We do not want that behavior, so we first check if the
+# package exists, then use the package module to install it if it does not
+# exist.
 - name: Ensure required packages are installed
   package:
-    name: "{{ __crypto_policies_packages }}"
+    name: "{{ item }}"
     state: present
+  loop: "{{ __crypto_policies_packages }}"
+  when: not item in ansible_facts.packages
 
 - include_tasks: gather_facts.yml
 

--- a/tests/tests_no_package_update.yml
+++ b/tests/tests_no_package_update.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Ensure that running the role does not update packages
+  hosts: all
+  tasks:
+    - name: Get package facts
+      package_facts:
+      no_log: true
+
+    - name: Save current package facts
+      set_fact:
+        __crypto_policies_packages_before: "{{ ansible_facts.packages }}"
+      no_log: true
+
+    - name: Include role
+      include_role:
+        name: linux-system-roles.crypto_policies
+
+    - name: Refresh package facts
+      package_facts:
+      no_log: true
+
+    - name: Verify packages were not changed
+      assert:
+        that: ansible_facts.packages == __crypto_policies_packages_before


### PR DESCRIPTION
There is a difference in behavior of the `package` (`dnf`) module
between ansible 2.8 and 2.9.  If you do this on 2.8:
```yaml
- name: install
  package:
    name: somepackage
    state: present
```
It will upgrade the package if it already exists and there is a newer
version.  Ansible 2.9 will not upgrade the package.

This causes problems for crypto-policies because we do not want to
alter the state of the system if we do not need to.  The solution is
to use `package_facts` to get the list of packages on the target
system, and only install the package from `__crypto_policies_packages`
if it does not exist.  It is the responsibility of the user to update
the packages on the managed nodes if the user wants to use the latest
packages.

Note that `dnf -y install somepackage` on EL8 will update the package
if it exists, so the `dnf` module in Ansible 2.9 has a different
behavior than the `dnf` command.