### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,7 +37,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,9 +5,7 @@ dependency:
 driver:
   name: docker
 lint:
-  name: yamllint
-  options:
-    config-file: .yamllint.yml
+  enabled: false
 platforms:
   - name: centos-8
     image: registry.centos.org/centos:8
@@ -18,10 +16,10 @@ platforms:
 provisioner:
   name: ansible
   log: true
-  lint:
-    name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
+  lint:
+    enabled: false
 scenario:
   name: default
   test_sequence:
@@ -31,7 +29,3 @@ scenario:
     - idempotence
     - check
     - destroy
-verifier:
-  name: testinfra
-  lint:
-    name: flake8


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.