### PR TITLE
remove ansible 2.7 support from molecule

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,8 +13,6 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     command: /usr/lib/systemd/systemd --system
-    groups:
-      - py3
 provisioner:
   name: ansible
   log: true
@@ -22,10 +20,6 @@ provisioner:
     enabled: false
   playbooks:
     converge: ../../tests/tests_default.yml
-  inventory:
-    group_vars:
-      py3:
-        ansible_python_interpreter: /usr/bin/python3
 scenario:
   name: default
   test_sequence:


### PR DESCRIPTION
ansible 2.7 has been deprecated
https://docs.ansible.com/ansible/devel/reference_appendices/release_and_maintenance.html
We need to remove ansible 2.7 from molecule testing in order to
* make room for ansible 2.10 testing
* move to molecule v3

ansible 2.8 and later support platform-python on el8 and later
so we don't have to handle that case explicitly by setting
ansible_python_interpreter for centos8 in molecule.yml