### PR TITLE
CI: Add support for RHEL-9

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
     - name: EL
       versions:
         - 8
+        - 9
 
   galaxy_tags:
     - crypto


### PR DESCRIPTION
The rhel-8-y status is the latest unreleased RHEL-8 and the rhel-x status is pre-released RHEL-9.