### PR TITLE
tests: Use a module that is available in all systems

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -18,5 +18,5 @@
               - "'DEFAULT' in crypto_policies_available_policies"
               - "'FUTURE' in crypto_policies_available_policies"
               - "'LEGACY' in crypto_policies_available_policies"
-              - "'NO-CAMELLIA' in crypto_policies_available_modules"
+              - "'AD-SUPPORT' in crypto_policies_available_modules"
               - crypto_policies_reboot_required is not defined


### PR DESCRIPTION
The `NO-CAMELLIA` is not available in RHEL9 package anymore so switching to `AD-SUPPORT` which is available everywhere and looks like it will last.