### PR TITLE
rename 'policy modules' to 'subpolicies'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ following section.
  * `crypto_policies_policy`
 
 Use this variable to specify the desired crypto policy on the target system,
-which can be either the base policy or a base policy with policy submodule(s)
+which can be either the base policy or a base policy with subpolicies
 as accepted by the `update-crypto-policies` tool. For example `FUTURE` or
-`DEFAULT:NO-SHA1:GOST`. The specified base policy and policy submodule(s)
+`DEFAULT:NO-SHA1:GOST`. The specified base policy and subpolicies
 must be available on the target system.
 
 The default value is `null` meaning the configuration is not changed and
 the role will just collect the facts below.
 
 The list of available base policies on the target system can be found in the
-`crypto_policies_available_policies` variable and the list of available policy
-submodules can be found in the `crypto_policies_available_modules` variable.
+`crypto_policies_available_policies` variable and the list of available
+subpolicies can be found in the `crypto_policies_available_subpolicies` variable.
 
  * `crypto_policies_reload`
 
@@ -61,15 +61,19 @@ by `crypto_policies_policy` variable above.
 * `crypto_policies_available_policies`
 
 This is a list of all base policies available on the target system.
-A custom policy files can be installed by copying the `.pol` files into
+Custom policy files can be installed by copying the `.pol` files into
 `/etc/crypto-policies/policies` directory (not implemented in this role yet).
+
+* `crypto_policies_available_subpolicies`
+
+This is a list of all subpolicies available on the target system.
+Custom subpolicies can be installed by copying the `.pmod` files into
+`/etc/crypto-policies/policies/modules` directory (not implemented in this
+role yet).
 
 * `crypto_policies_available_modules`
 
-This is a list of all policy submodules available on the target system.
-A custom policy submodule can be installed by copying the `.pmod` files into
-`/etc/crypto-policies/policies/modules` directory (not implemented in this
-role yet).
+Deprecated alias to `crypto_policies_available_subpolicies`.
 
 * `crypto_policies_reboot_required`
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,19 +46,25 @@
         | map('basename') | map('splitext') | map('first') | unique | list }}
     cacheable: true
 
-- name: Find policy module files
+- name: Find subpolicy files
   find:
     paths:
       - /usr/share/crypto-policies/policies/modules/
       - /etc/crypto-policies/policies/modules/
     patterns: '*.pmod'
-  register: __crypto_policies_policy_module
+  register: __crypto_policies_subpolicies
 
-- name: Set available policy modules fact
+- name: Set available subpolicies fact
+  set_fact:
+    crypto_policies_available_subpolicies: >-
+      {{ __crypto_policies_subpolicies.files | map(attribute='path')
+        | map('basename') | map('splitext') | map('first') | unique | list }}
+    cacheable: true
+
+- name: Set crypto_policies_available_modules fact (deprecated)
   set_fact:
     crypto_policies_available_modules: >-
-      {{ __crypto_policies_policy_module.files | map(attribute='path')
-        | map('basename') | map('splitext') | map('first') | unique | list }}
+      {{ crypto_policies_available_subpolicies }}
     cacheable: true
 
 - name: Update crypto policy if needed
@@ -67,7 +73,7 @@
       {{ '--no-reload' if not crypto_policies_reload else '' }}
       --set {{ crypto_policies_policy }}
   when:
-    # TODO check with available policies and modules
+    # TODO check with available policies and subpolicies
     - crypto_policies_policy is not none
     - crypto_policies_policy != crypto_policies_active
   notify: __crypto_policies_handler_modified
@@ -76,7 +82,7 @@
   set_fact:
     crypto_policies_reboot_required: true
   when:
-    # TODO check with available policies and modules
+    # TODO check with available policies and subpolicies
     - crypto_policies_policy is not none
     - crypto_policies_policy != crypto_policies_active
 

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -19,4 +19,5 @@
               - "'FUTURE' in crypto_policies_available_policies"
               - "'LEGACY' in crypto_policies_available_policies"
               - "'AD-SUPPORT' in crypto_policies_available_modules"
+              - "'AD-SUPPORT' in crypto_policies_available_subpolicies"
               - crypto_policies_reboot_required is not defined

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -16,13 +16,13 @@
           - crypto_policies_active == 'LEGACY'
           - crypto_policies_reboot_required | bool
 
-    - name: Set correct base policy and policy module
+    - name: Set correct base policy and subpolicy
       include_role:
         name: linux-system-roles.crypto_policies
       vars:
         crypto_policies_policy: DEFAULT:NO-SHA1
         crypto_policies_reload: false
-    - name: Verify that base policy and policy module were updated
+    - name: Verify that base policy and subpolicy were updated
       assert:
         that:
           - crypto_policies_active == 'DEFAULT:NO-SHA1'
@@ -47,9 +47,9 @@
               - ansible_failed_result.msg != 'UNREACH'
             msg: "Role has not failed when it should have"
 
-    - name: Setting incorrect policy module should fail
+    - name: Setting incorrect subpolicy should fail
       block:
-        - name: Set incorrect policy module
+        - name: Set incorrect subpolicy
           include_role:
             name: linux-system-roles.crypto_policies
           vars:


### PR DESCRIPTION
This follows the renaming done in upstream crypto-policies: https://gitlab.com/redhat-crypto/fedora-crypto-policies/-/merge_requests/101/diffs