### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,7 @@
 # SPDX-License-Identifier: MIT
 ---
-
 - name: Set platform/version specific variables
-  include_vars: "{{ __crypto_policies_vars_file }}"
-  loop:
-    - "{{ ansible_facts['os_family'] }}.yml"
-    - "{{ ansible_facts['distribution'] }}.yml"
-    - "{{ ansible_facts['distribution'] ~ '_' ~
-          ansible_facts['distribution_major_version'] }}.yml"
-    - "{{ ansible_facts['distribution'] ~ '_' ~
-          ansible_facts['distribution_version'] }}.yml"
-  vars:
-    __crypto_policies_vars_file: "{{ role_path }}/vars/{{ item }}"
-  when: __crypto_policies_vars_file is file
+  include_tasks: set_vars.yml
 
 - name: Ensure required packages are installed
   package:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__crypto_policies_required_facts) ==
+    __crypto_policies_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ __vars_file }}"
+  loop:
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_major_version'] }}.yml
+    - >-
+      {{ ansible_facts['distribution'] ~ '_' ~
+      ansible_facts['distribution_version'] }}.yml
+  vars:
+    __vars_file: "{{ role_path }}/vars/{{ item }}"
+  when: __vars_file is file

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.crypto_policies
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __crypto_policies_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -4,7 +4,7 @@
   hosts: all
   roles:
     - linux-system-roles.crypto_policies
-
+  gather_facts: false
   tasks:
     - name: Verify the facts are correctly set
       block:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,3 +2,10 @@
 ---
 
 __crypto_policies_packages: ["crypto-policies", "crypto-policies-scripts"]
+
+# ansible_facts required by the role
+__crypto_policies_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
