### PR TITLE
Add cleanup to some tests to facilitate 'shared' test runs

### DIFF
--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -20,4 +20,3 @@
               - "'LEGACY' in crypto_policies_available_policies"
               - "'AD-SUPPORT' in crypto_policies_available_modules"
               - "'AD-SUPPORT' in crypto_policies_available_subpolicies"
-              - crypto_policies_reboot_required is not defined

--- a/tests/tests_reboot.yml
+++ b/tests/tests_reboot.yml
@@ -4,19 +4,41 @@
   hosts: all
   tags:
     - tests::reboot
-  roles:
-    - role: linux-system-roles.crypto_policies
-      vars:
-        crypto_policies_policy: FUTURE
-        crypto_policies_reboot_ok: true
 
   tasks:
-    - name: Verify the facts are correctly set
-      block:
-        - meta: flush_handlers
+    - block:
+        - name: Ensure we can set crypto policy including reboot of the system
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: FUTURE
+            crypto_policies_reboot_ok: true
+        - name: Verify the facts are correctly set
+          block:
+            - meta: flush_handlers
 
-        - name: Check the current policy is FUTURE
-          assert:
-            that:
-              - crypto_policies_active == 'FUTURE'
-              - not crypto_policies_reboot_required
+            - name: Check the current policy is FUTURE
+              assert:
+                that:
+                  - crypto_policies_active == 'FUTURE'
+                  - not crypto_policies_reboot_required
+
+      always:
+        - name: Restore policy to DEFAULT
+          tags:
+            - tests::cleanup
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: DEFAULT
+            crypto_policies_reboot_ok: true
+        - name: Check restoration
+          tags:
+            - tests::cleanup
+          block:
+            - meta: flush_handlers
+            - name: Check the current policy has been restored to DEFAULT
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT'
+                  - not crypto_policies_reboot_required

--- a/tests/tests_reload.yml
+++ b/tests/tests_reload.yml
@@ -3,54 +3,74 @@
 - name: Ensure that crypto_policy_reload variable works
   hosts: all
   tasks:
+    - block:
 
-    - name: Run role to make sure all dependencies are installed
-      include_role:
-        name: linux-system-roles.crypto_policies
+        - name: Run role to make sure all dependencies are installed
+          include_role:
+            name: linux-system-roles.crypto_policies
 
-    - name: Get SSHD pid before policy update
-      slurp:
-        src: /var/run/sshd.pid
-      register: sshd_pid_before
+        - name: Get SSHD pid before policy update
+          slurp:
+            src: /var/run/sshd.pid
+          register: sshd_pid_before
 
-    - name: Change policy from DEFAULT TO LEGACY (disable reload)
-      include_role:
-        name: linux-system-roles.crypto_policies
-      vars:
-        crypto_policies_policy: LEGACY
-        crypto_policies_reload: false
+        - name: Change policy from DEFAULT TO LEGACY (disable reload)
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: LEGACY
+            crypto_policies_reload: false
 
-    - name: Get sshd pid after first update
-      slurp:
-        src: /var/run/sshd.pid
-      register: sshd_pid_after_first
+        - name: Get sshd pid after first update
+          slurp:
+            src: /var/run/sshd.pid
+          register: sshd_pid_after_first
 
-    - name: Verify that policy was changed to LEGACY
-      assert:
-        that:
-          - crypto_policies_active == 'LEGACY'
-    - name: Check the sshd was not reloaded
-      assert:
-        that:
-          - sshd_pid_before.content == sshd_pid_after_first.content
+        - name: Verify that policy was changed to LEGACY
+          assert:
+            that:
+              - crypto_policies_active == 'LEGACY'
+        - name: Check the sshd was not reloaded
+          assert:
+            that:
+              - sshd_pid_before.content == sshd_pid_after_first.content
 
-    - name: Change policy from LEGACY to DEFAULT (reload by default)
-      include_role:
-        name: linux-system-roles.crypto_policies
-      vars:
-        crypto_policies_policy: DEFAULT
+        - name: Change policy from LEGACY to DEFAULT (reload by default)
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: DEFAULT
 
-    - name: Get sshd pid after second update
-      slurp:
-        src: /var/run/sshd.pid
-      register: sshd_pid_after_second
+        - name: Get sshd pid after second update
+          slurp:
+            src: /var/run/sshd.pid
+          register: sshd_pid_after_second
 
-    - name: Verify that policy was changed to DEFAULT
-      assert:
-        that:
-          - crypto_policies_active == 'DEFAULT'
+        - name: Verify that policy was changed to DEFAULT
+          assert:
+            that:
+              - crypto_policies_active == 'DEFAULT'
 
-    - name: Check the sshd was reloaded
-      assert:
-        that:
-          - sshd_pid_after_first.content != sshd_pid_after_second.content
+        - name: Check the sshd was reloaded
+          assert:
+            that:
+              - sshd_pid_after_first.content != sshd_pid_after_second.content
+
+      always:
+        - name: Restore policy to DEFAULT
+          tags:
+            - tests::cleanup
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: DEFAULT
+        - name: Check restoration
+          tags:
+            - tests::cleanup
+          block:
+            - meta: flush_handlers
+            - name: Check the current policy has been restored to DEFAULT
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT'
+                  - crypto_policies_reboot_required | bool

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -3,65 +3,85 @@
 - name: Ensure that we can set the policy using this role (without reboot)
   hosts: all
   tasks:
+    - block:
 
-    - name: Set correct base policy
-      include_role:
-        name: linux-system-roles.crypto_policies
-      vars:
-        crypto_policies_policy: LEGACY
-        crypto_policies_reload: false
-    - name: Verify that base policy was updated
-      assert:
-        that:
-          - crypto_policies_active == 'LEGACY'
-          - crypto_policies_reboot_required | bool
-
-    - name: Set correct base policy and subpolicy
-      include_role:
-        name: linux-system-roles.crypto_policies
-      vars:
-        crypto_policies_policy: DEFAULT:NO-SHA1
-        crypto_policies_reload: false
-    - name: Verify that base policy and subpolicy were updated
-      assert:
-        that:
-          - crypto_policies_active == 'DEFAULT:NO-SHA1'
-          - crypto_policies_reboot_required | bool
-
-    - name: Setting incorrect base policy should fail
-      block:
-        - name: Set incorrect base policy
+        - name: Set correct base policy
           include_role:
             name: linux-system-roles.crypto_policies
           vars:
-            crypto_policies_policy: NOEXIST
+            crypto_policies_policy: LEGACY
             crypto_policies_reload: false
-        - name: unreachable task
-          fail:
-            msg: UNREACH
-      rescue:
-        - name: Check that we failed in the role
+        - name: Verify that base policy was updated
           assert:
             that:
-              - crypto_policies_active == 'DEFAULT:NO-SHA1'
-              - ansible_failed_result.msg != 'UNREACH'
-            msg: "Role has not failed when it should have"
+              - crypto_policies_active == 'LEGACY'
+              - crypto_policies_reboot_required | bool
 
-    - name: Setting incorrect subpolicy should fail
-      block:
-        - name: Set incorrect subpolicy
+        - name: Set correct base policy and subpolicy
           include_role:
             name: linux-system-roles.crypto_policies
           vars:
-            crypto_policies_policy: DEFAULT:NOEXIST
+            crypto_policies_policy: DEFAULT:NO-SHA1
             crypto_policies_reload: false
-        - name: unreachable task
-          fail:
-            msg: UNREACH
-      rescue:
-        - name: Check that we failed in the role
+        - name: Verify that base policy and subpolicy were updated
           assert:
             that:
               - crypto_policies_active == 'DEFAULT:NO-SHA1'
-              - ansible_failed_result.msg != 'UNREACH'
-            msg: "Role has not failed when it should have"
+              - crypto_policies_reboot_required | bool
+
+        - name: Setting incorrect base policy should fail
+          block:
+            - name: Set incorrect base policy
+              include_role:
+                name: linux-system-roles.crypto_policies
+              vars:
+                crypto_policies_policy: NOEXIST
+                crypto_policies_reload: false
+            - name: unreachable task
+              fail:
+                msg: UNREACH
+          rescue:
+            - name: Check that we failed in the role
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT:NO-SHA1'
+                  - ansible_failed_result.msg != 'UNREACH'
+                msg: "Role has not failed when it should have"
+
+        - name: Setting incorrect subpolicy should fail
+          block:
+            - name: Set incorrect subpolicy
+              include_role:
+                name: linux-system-roles.crypto_policies
+              vars:
+                crypto_policies_policy: DEFAULT:NOEXIST
+                crypto_policies_reload: false
+            - name: unreachable task
+              fail:
+                msg: UNREACH
+          rescue:
+            - name: Check that we failed in the role
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT:NO-SHA1'
+                  - ansible_failed_result.msg != 'UNREACH'
+                msg: "Role has not failed when it should have"
+
+      always:
+        - name: Restore policy to DEFAULT
+          tags:
+            - tests::cleanup
+          include_role:
+            name: linux-system-roles.crypto_policies
+          vars:
+            crypto_policies_policy: DEFAULT
+        - name: Check restoration
+          tags:
+            - tests::cleanup
+          block:
+            - meta: flush_handlers
+            - name: Check the current policy has been restored to DEFAULT
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT'
+                  - crypto_policies_reboot_required | bool


### PR DESCRIPTION
crypto_policies_reboot_required being a tri-state
doesn't allow me to do that cleanly