### PR TITLE
ansible-lint - add changed_when true

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,6 +56,7 @@
     # TODO check with available policies and subpolicies
     - crypto_policies_policy is not none
     - crypto_policies_policy != crypto_policies_active
+  changed_when: true
   notify: __crypto_policies_handler_modified
 
 - name: Set the reboot_required flag if needed


### PR DESCRIPTION
```
tasks/main.yml:50: no-changed-when: Commands should not change things if nothing needs doing.
```
add `changed_when: true` so the command will report changed if the `when`
condition is true and the command is run

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
