### PR TITLE
ci: ensure dependabot git commit message conforms to commitlint

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: /
     schedule:
       interval: monthly
+    commit-message:
+      prefix: ci


### PR DESCRIPTION
Ensure dependabot git commit message conforms to commitlint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
