### PR TITLE
fix: add support for EL10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,11 +4,8 @@ galaxy_info:
   author: Jakub Jelen <jjelen@redhat.com>
   description: This Ansible role manages system-wide crypto policies.
   company: Red Hat, Inc.
-
   license: MIT
-
   min_ansible_version: "2.9"
-
   platforms:
     - name: Fedora
       versions:
@@ -17,24 +14,25 @@ galaxy_info:
       versions:
         - "8"
         - "9"
-
   galaxy_tags:
-    - crypto
-    - tls
-    - ssh
-    - security
-    - fedora
-    - redhat
-    - openssl
-    - nss
-    - gnutls
-    - openssh
     - bind
-    - krb5
-    - kerberos
+    - crypto
+    - el8
+    - el9
+    - el10
+    - fedora
+    - gnutls
     - java
+    - kerberos
+    - krb5
     - libssh
-    - system
     - networking
-
+    - nss
+    - openssh
+    - openssl
+    - redhat
+    - security
+    - ssh
+    - system
+    - tls
 dependencies: []

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -17,16 +17,24 @@
               - crypto_policies_active == 'LEGACY'
               - crypto_policies_reboot_required | bool
 
+        - name: Set policy and subpolicy to use for test
+          set_fact:
+            __policy_and_sub: "{{ 'DEFAULT:NO-SHA1'
+              if 'NO-SHA1' in crypto_policies_available_subpolicies
+              else 'DEFAULT:AD-SUPPORT'
+              if 'AD-SUPPORT' in crypto_policies_available_subpolicies
+              else 'DEFAULT:' ~ crypto_policies_available_subpolicies[0] }}"
+
         - name: Set correct base policy and subpolicy
           include_role:
             name: linux-system-roles.crypto_policies
           vars:
-            crypto_policies_policy: DEFAULT:NO-SHA1
+            crypto_policies_policy: "{{ __policy_and_sub }}"
             crypto_policies_reload: false
         - name: Verify that base policy and subpolicy were updated
           assert:
             that:
-              - crypto_policies_active == 'DEFAULT:NO-SHA1'
+              - crypto_policies_active == __policy_and_sub
               - crypto_policies_reboot_required | bool
 
         - name: Setting incorrect base policy should fail
@@ -44,7 +52,7 @@
             - name: Check that we failed in the role
               assert:
                 that:
-                  - crypto_policies_active == 'DEFAULT:NO-SHA1'
+                  - crypto_policies_active == __policy_and_sub
                   - ansible_failed_result.msg != 'UNREACH'
                 msg: "Role has not failed when it should have"
 
@@ -63,7 +71,7 @@
             - name: Check that we failed in the role
               assert:
                 that:
-                  - crypto_policies_active == 'DEFAULT:NO-SHA1'
+                  - crypto_policies_active == __policy_and_sub
                   - ansible_failed_result.msg != 'UNREACH'
                 msg: "Role has not failed when it should have"
 


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

In addition - for roles that have different variable files for EL9, create
the corresponding EL10 files.

Fix tests_update.yml - centos 10 has no NO-SHA1 subpolicy

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
