### PR TITLE
ci: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ need reboot. If there are no other tasks in the playbook that require reboot,
 you can set this value to `true` and this role will handle the reboot for you,
 when needed.
 
+* `crypto_policies_transactional_update_reboot_ok`
+
+This variable is used to handle reboots required by transactional updates.
+If a transactional update requires a reboot, the role will proceed with the
+reboot if crypto_policies_transactional_update_reboot_ok is set to true. If set
+to false, the role will notify the user that a reboot is required, allowing
+for custom handling of the reboot requirement. If this variable is not set,
+the role will fail to ensure the reboot requirement is not overlooked.
+
 ### Variables Exported by the Role
 
 * `crypto_policies_active`
@@ -99,10 +108,10 @@ to do by the user afterwards).
 - name: Manage crypto policies
   hosts: all
   roles:
-    role: linux-system-roles.crypto_policies
-    vars:
-      crypto_policies_policy: "DEFAULT:NO-SHA1"
-      crypto_policies_reload: false
+    - role: linux-system-roles.crypto_policies
+      vars:
+        crypto_policies_policy: "DEFAULT:NO-SHA1"
+        crypto_policies_reload: false
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ when needed.
 
 This variable is used to handle reboots required by transactional updates.
 If a transactional update requires a reboot, the role will proceed with the
-reboot if crypto_policies_transactional_update_reboot_ok is set to true. If set
-to false, the role will notify the user that a reboot is required, allowing
+reboot if `crypto_policies_transactional_update_reboot_ok` is set to `true`. If set
+to `false`, the role will notify the user that a reboot is required, allowing
 for custom handling of the reboot requirement. If this variable is not set,
 the role will fail to ensure the reboot requirement is not overlooked.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@
 crypto_policies_policy: null
 crypto_policies_reload: true
 crypto_policies_reboot_ok: false
+crypto_policies_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,30 @@
     state: present
     use: "{{ (__crypto_policies_is_ostree | d(false)) |
       ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: crypto_policies_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __crypto_policies_is_transactional | d(false)
+    - crypto_policies_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: crypto_policies_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set
+          'crypto_policies_transactional_update_reboot_ok' to proceed.
+      when:
+        - crypto_policies_transactional_update_reboot_ok is none
 
 - name: Gather facts
   include_tasks: gather_facts.yml

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,18 @@
       set_fact:
         __crypto_policies_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __crypto_policies_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __crypto_policies_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ __vars_file }}"
   loop:


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README and minor fix in README example.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
