### PR TITLE
feat: Support this role in container environments and builds

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
 
       - name: Convert role to collection format
         id: collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -105,7 +105,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.9.1"
 
       - name: Configure tox-lsr
         if: steps.check_platform.outputs.supported

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,8 @@ galaxy_info:
         - "9"
   galaxy_tags:
     - bind
+    - container
+    - containerbuild
     - crypto
     - el8
     - el9

--- a/tests/tests_reload.yml
+++ b/tests/tests_reload.yml
@@ -2,6 +2,8 @@
 ---
 - name: Ensure that crypto_policy_reload variable works
   hosts: all
+  tags:
+    - tests::booted
   tasks:
     - name: Run test
       block:


### PR DESCRIPTION
Feature: Support running the crypto_policies role during container builds and in container environments.

Reason: This is particularly useful for building bootc derivative OSes. It's also desirable to run roles in system containers.

Result: These flags enable running the container scenarios in CI, which ensures that the role works in podman system containers as well as buildah build environment and thus allows us to officially support this role for image mode builds.

See https://issues.redhat.com/browse/RHEL-78157

## Summary by Sourcery

Enable the crypto_policies role to operate within container environments and image builds by extending metadata, updating test tags, and bumping CI tooling versions

New Features:
- Support running the role in container environments and build contexts

CI:
- Upgrade tox-lsr to v3.9.1 across CI workflows

Tests:
- Tag the reload test playbook for booted container scenarios