### PR TITLE
docs(changelog): version 1.5.0 [citest skip]

### DIFF
--- a/.README.html
+++ b/.README.html
@@ -58,8 +58,9 @@ SOFTWARE.
   </style>
   <style type="text/css">code{white-space: pre;}</style>
   <style type="text/css">
+html { -webkit-text-size-adjust: 100%; }
 pre > code.sourceCode { white-space: pre; position: relative; }
-pre > code.sourceCode > span { line-height: 1.25; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
 pre > code.sourceCode > span:empty { height: 1.2em; }
 .sourceCode { overflow: visible; }
 code.sourceCode > span { color: inherit; text-decoration: inherit; }
@@ -70,7 +71,7 @@ div.sourceCode { overflow: auto; }
 }
 @media print {
 pre > code.sourceCode { white-space: pre-wrap; }
-pre > code.sourceCode > span { display: inline-block; text-indent: -5em; padding-left: 5em; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
 }
 pre.numberSource code
   { counter-reset: source-line 0; }
@@ -176,8 +177,8 @@ the following section.</p>
 system, which can be either the base policy or a base policy with
 subpolicies as accepted by the <code>update-crypto-policies</code> tool.
 For example <code>FUTURE</code> or <code>DEFAULT:NO-SHA1:GOST</code>.
-The specified base policy and subpolicies must be available on the
-target system.</p>
+The specified base policy and subpolicies <!-- codespell:ignore gost -->
+must be available on the target system.</p>
 <p>The default value is <code>null</code> meaning the configuration is
 not changed and the role will just collect the facts below.</p>
 <p>The list of available base policies on the target system can be found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,31 @@
 Changelog
 =========
 
+[1.5.0] - 2025-06-23
+--------------------
+
+### New Features
+
+- feat: Support this role in container environments and builds (#151)
+
+### Other Changes
+
+- ci: ansible-plugin-scan is disabled for now (#136)
+- ci: bump ansible-lint to v25; provide collection requirements for ansible-lint (#139)
+- ci: Check spelling with codespell (#140)
+- ci: Add test plan that runs CI tests and customize it for each role (#141)
+- ci: In test plans, prefix all relate variables with SR_ (#142)
+- ci: Fix bug with ARTIFACTS_URL after prefixing with SR_ (#143)
+- ci: several changes related to new qemu test, ansible-lint, python versions, ubuntu versions (#144)
+- ci: use tox-lsr 3.6.0; improve qemu test logging (#145)
+- ci: skip storage scsi, nvme tests in github qemu ci (#146)
+- ci: Bump sclorg/testing-farm-as-github-action from 3 to 4 (#147)
+- ci: bump tox-lsr to 3.8.0; rename qemu/kvm tests (#148)
+- ci: Add Fedora 42; use tox-lsr 3.9.0; use lsr-report-errors for qemu tests (#150)
+- ci: Add support for bootc end-to-end validation tests (#152)
+- tests: Add bootc end-to-end validation test (#153)
+- ci: Use ansible 2.19 for fedora 42 testing; support python 3.13 (#154)
+
 [1.4.2] - 2025-01-09
 --------------------
 


### PR DESCRIPTION
Update changelog and .README.html for version 1.5.0

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Prepare release 1.5.0 by adding container environment support, refreshing CI workflows, introducing bootc end-to-end tests, fixing artifact URL handling, and enhancing README styling.

New Features:
- Support this role in container environments and builds

Bug Fixes:
- Fix ARTIFACTS_URL handling after SR_ variable prefix

CI:
- Revamp CI workflows: disable ansible-plugin-scan, bump ansible-lint to v25, add codespell, integrate per-role SR_-prefixed test plans, refine QEMU tests (logging, skipping scsi/nvme, renaming), bump testing-farm action, and support Fedora 42 and Python 3.13

Documentation:
- Improve README.html code block styling and add a codespell ignore directive for 'gost'

Tests:
- Add bootc end-to-end validation test