### PR TITLE
ci: ansible-lint requires dependencies to be installed [citest_skip]

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -44,17 +44,20 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.versions.python }}
 
-      - name: Convert role to collection format and run ansible-lint
+      - name: Convert role to collection format
+        run: tox -e collection
+
+      - name: Run ansible-lint
         run: |
           set -euxo pipefail
           LSR_ANSIBLE_LINT_DEP="ansible-lint==${{ matrix.versions.ansible_lint }}" \
           LSR_ANSIBLE_LINT_ANSIBLE_DEP="ansible-core==${{ matrix.versions.ansible }}" \
           tox -x testenv:ansible-lint-collection.basepython="python${{ matrix.versions.python }}" \
-          -e collection,ansible-lint-collection
+          -e ansible-lint-collection

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -47,15 +47,18 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
 
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.versions.python }}
 
-      - name: Convert role to collection format and run ansible-test
+      - name: Convert role to collection format
+        run: tox -e collection
+
+      - name: Run ansible-test
         run: |
           tox \
             -x testenv:ansible-test-${{ matrix.versions.ansible }}.basepython="python${{ matrix.versions.python }}" \
-            -e collection,ansible-test-${{ matrix.versions.ansible }}
+            -e ansible-test-${{ matrix.versions.ansible }}

--- a/.github/workflows/qemu-kvm-integration-tests.yml
+++ b/.github/workflows/qemu-kvm-integration-tests.yml
@@ -110,7 +110,7 @@ jobs:
           python3 -m pip install --upgrade pip
           sudo apt update
           sudo apt install -y --no-install-recommends git ansible-core genisoimage qemu-system-x86
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.18.1"
 
       # HACK: Drop this when moving this workflow to 26.04 LTS
       - name: Update podman to 5.x for compatibility with bootc-image-builder's podman 5


### PR DESCRIPTION
ansible-lint requires the dependencies in meta/collection-requirements.yml
and tests/collection-requirements.yml to be installed.  tox-lsr 3.18.1
will ensure they are installed.

Refactor the tests somewhat so that the collection and test steps are separate.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Update CI workflows to use the latest tox-lsr and separate Ansible collection conversion from lint and test execution.

CI:
- Bump tox-lsr to version 3.18.1 across Ansible-related GitHub Actions workflows.
- Split collection conversion into its own tox step before running ansible-lint and ansible-test jobs in CI.