### PR TITLE
feat: regenerate policy automatically if check fails, add crypto_policies_force_regenerate

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,27 @@ the daemons affected by crypto policies in the system. Setting `false`
 prevents this behavior and is helpful if the role is executed during system
 enrollment or some other follow-up tasks is expected to do it later.
 
+* `crypto_policies_force_regenerate`
+
+The default value is `false`.  Setting this to `true` will force the role to
+regenerate the active crypto policy.  When should this be used?  When the crypto
+policy configuration on the system has been modified (for example, editing
+subpolicy files), and this is not detected by `update-crypto-policies --check`,
+and you want to force the policy to be regenerated.  The role will automatically
+regenerate the active crypto policy in these cases:
+
+* The user sets `crypto_policies_policy` and the policy is different than the
+  current policy.
+* The user manually updates a policy or subpolicy file and this is detected by
+  `update-crypto-policies --check`
+
+However, there may be cases when the changes to the crypto policy configuration
+are not detected by `update-crypto-policies --check`.  You can set
+`crypto_policies_force_regenerate: true` to force the policy to be regenerated.
+On RHEL/CentOS 8 and other platforms where `update-crypto-policies --check` is
+not supported, you must set `crypto_policies_force_regenerate: true` after
+modifying policy or subpolicy files so the role can regenerate the active policy.
+
 * `crypto_policies_reboot_ok`
 
 Crypto policies can not know all the custom applications using crypto

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,5 +5,6 @@
 
 crypto_policies_policy: null
 crypto_policies_reload: true
+crypto_policies_force_regenerate: false
 crypto_policies_reboot_ok: false
 crypto_policies_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,14 +84,50 @@
     - crypto_policies_policy != crypto_policies_active
   changed_when: true
   notify: __crypto_policies_handler_modified
+  register: __crypto_policies_update_policy
+
+- name: Regenerate crypto policy when update was not needed
+  when: __crypto_policies_update_policy is skipped
+  block:
+    - name: Check if update-crypto-policies supports --check
+      command: update-crypto-policies --help
+      register: __crypto_policies_update_help
+      changed_when: false
+
+    - name: Check whether configured policy matches generated policy
+      command: update-crypto-policies --check
+      register: __crypto_policies_check
+      changed_when: false
+      failed_when: false
+      when: "'--check' in __crypto_policies_update_help.stdout"
+
+    - name: Regenerate crypto policy if needed
+      command: update-crypto-policies
+      when:
+        - >-
+          crypto_policies_force_regenerate | bool
+          or (
+            __crypto_policies_check is defined
+            and not __crypto_policies_check.skipped | default(false)
+            and __crypto_policies_check.rc | d(0) == 1
+            and (
+              "The configured policy does NOT match the generated policy"
+              in __crypto_policies_check.stderr | d("")
+            )
+          )
+      changed_when: true
+      register: __crypto_policies_regenerate_policy
+      notify: __crypto_policies_handler_modified
 
 - name: Set the reboot_required flag if needed
   set_fact:
     crypto_policies_reboot_required: true
   when:
     # TODO check with available policies and subpolicies
-    - crypto_policies_policy is not none
-    - crypto_policies_policy != crypto_policies_active
+    - (__crypto_policies_regenerate_policy is defined and
+       __crypto_policies_regenerate_policy is changed) or
+      (__crypto_policies_update_policy is defined and
+       __crypto_policies_update_policy is changed)
 
 - name: Update facts after applying policy
   include_tasks: gather_facts.yml

--- a/tests/tests_update.yml
+++ b/tests/tests_update.yml
@@ -71,6 +71,134 @@
                   - ansible_failed_result.msg != 'UNREACH'
                 msg: "Role has not failed when it should have"
 
+        - name: Test custom subpolicy and update-crypto-policies --check
+          block:
+            - name: Check if update-crypto-policies supports --check
+              command: update-crypto-policies --help
+              register: __ucp_help
+              changed_when: false
+
+            - name: Set fact for --check support
+              set_fact:
+                __crypto_policies_check_supported: >-
+                  {{ '--check' in __ucp_help.stdout }}
+
+            - name: Create custom subpolicy file
+              copy:
+                dest: /etc/crypto-policies/policies/modules/TEST_POLICY.pmod
+                content: |
+                  # test subpolicy
+                  min_rsa_size = 2048
+                mode: "0644"
+
+            - name: Set policy with custom subpolicy
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                crypto_policies_policy: DEFAULT:TEST_POLICY
+                crypto_policies_reload: false
+
+            - name: Verify custom subpolicy was applied
+              assert:
+                that:
+                  - crypto_policies_active == 'DEFAULT:TEST_POLICY'
+                  - "'TEST_POLICY' in crypto_policies_available_subpolicies"
+
+            - name: Check policy is applied before subpolicy modification
+              command: update-crypto-policies --check
+              register: __check_before_modify
+              changed_when: false
+              when: __crypto_policies_check_supported | bool
+
+            - name: Verify policy matches before subpolicy modification
+              assert:
+                that:
+                  - __check_before_modify.rc == 0
+                  - >-
+                    'matches the generated policy'
+                    in __check_before_modify.stdout
+              when: __crypto_policies_check_supported | bool
+
+            - name: Get generated policy state before subpolicy modification
+              stat:
+                path: /etc/crypto-policies/state/CURRENT.pol
+              register: __policy_state_before_modify
+
+            - name: Modify custom subpolicy file
+              copy:
+                dest: /etc/crypto-policies/policies/modules/TEST_POLICY.pmod
+                content: |
+                  # test subpolicy modified
+                  min_rsa_size = 3072
+                mode: "0644"
+
+            - name: Get generated policy state after subpolicy modification
+              stat:
+                path: /etc/crypto-policies/state/CURRENT.pol
+              register: __policy_state_after_modify
+
+            - name: Verify generated policy unchanged after subpolicy modification
+              assert:
+                that:
+                  - >-
+                    __policy_state_after_modify.stat.checksum
+                    == __policy_state_before_modify.stat.checksum
+
+            - name: Check policy after subpolicy modification
+              command: update-crypto-policies --check
+              register: __check_after_modify
+              changed_when: false
+              failed_when: false
+              when: __crypto_policies_check_supported | bool
+
+            - name: Verify policy mismatch is reported after subpolicy modification
+              assert:
+                that:
+                  - __check_after_modify.rc == 1
+                  - >-
+                    'does NOT match the generated policy'
+                    in __check_after_modify.stderr
+              when: __crypto_policies_check_supported | bool
+
+            # When --check is supported, the role should detect drift and regenerate.
+            # On EL8 and other platforms without --check, force regeneration explicitly.
+            - name: Run role to regenerate policy after subpolicy modification
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              when: __crypto_policies_check_supported | bool
+
+            - name: Run role to regenerate policy when --check is not supported
+              include_tasks: tasks/run_role_with_clear_facts.yml
+              vars:
+                crypto_policies_force_regenerate: true
+              when: not __crypto_policies_check_supported | bool
+
+            - name: Check policy after role regenerated configuration
+              command: update-crypto-policies --check
+              register: __check_after_role
+              changed_when: false
+              when: __crypto_policies_check_supported | bool
+
+            - name: Verify policy matches after role regenerated configuration
+              assert:
+                that:
+                  - __check_after_role.rc == 0
+                  - >-
+                    'matches the generated policy'
+                    in __check_after_role.stdout
+              when: __crypto_policies_check_supported | bool
+
+            - name: Get generated policy state after role regenerated configuration
+              stat:
+                path: /etc/crypto-policies/state/CURRENT.pol
+              register: __policy_state_after_role
+
+            - name: Verify generated policy updated after role regenerated configuration
+              assert:
+                that:
+                  - >-
+                    __policy_state_after_role.stat.checksum
+                    != __policy_state_before_modify.stat.checksum
+              when: not __crypto_policies_check_supported | bool
+
       always:
         - name: Restore policy to DEFAULT
           tags:
@@ -78,6 +206,12 @@
           include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             crypto_policies_policy: DEFAULT
+        - name: Remove custom subpolicy file
+          tags:
+            - tests::cleanup
+          file:
+            path: /etc/crypto-policies/policies/modules/TEST_POLICY.pmod
+            state: absent
         - name: Check restoration
           tags:
             - tests::cleanup


### PR DESCRIPTION
Feature: The role will call `update-crypto-policies --check` to see if the policy
configuration has changed, and will regenerate the policy if so.  The user can also
force the policy to be regenerated by setting `crypto_policies_force_regenerate: true`.
This is needed on EL8 and other platforms which do not support `--check`.

Reason: The user may edit the policy configuration outside of the role, and the user needs
a way to regenerate the policy.

Result: The user can modify the policy configuration outside of the role and regenerate
the policy.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

Assisted-by: Cursor IDE using the models Composer 2.5, Sonnet 4.6, and Codex 5.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic verification of crypto policies and conditional regeneration when a mismatch is detected.
  * New option to force policy regeneration when automatic detection may miss manual edits (defaults to false).

* **Documentation**
  * Docs updated to describe the new force-regenerate option, defaults, and when to enable it.

* **Tests**
  * Added tests covering custom subpolicy changes and regeneration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->